### PR TITLE
Fix `FromElevatorDirection` spawntype to be less janky

### DIFF
--- a/Patch_FromElevatorDirection_Fix.cs
+++ b/Patch_FromElevatorDirection_Fix.cs
@@ -1,0 +1,73 @@
+﻿using AIGraph;
+using HarmonyLib;
+using Player;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using static SurvivalWave;
+using UnityEngine;
+
+namespace ExtraSurvivalWaveSettings
+{
+    [HarmonyPatch]
+    internal static class Patch_FromElevatorDirection_Fix
+    {
+        // FromElevatorDirection fix
+        [HarmonyPatch(typeof(SurvivalWave), nameof(SurvivalWave.GetScoredSpawnPoint_FromElevator))]
+        [HarmonyPrefix]
+        private static bool GetScoredSpawnPoint_FromElevator(SurvivalWave __instance, ref ScoredSpawnPoint __result)
+        {
+            AIG_CourseNode startCourseNode = __instance.m_courseNode.m_dimension.GetStartCourseNode();
+            AIG_CourseNode? courseNode = null;
+
+            int closestDist = int.MaxValue;
+            // Find closest reachable alive player
+            foreach (PlayerAgent player in PlayerManager.PlayerAgentsInLevel)
+            {
+                if (player.Alive && SurvivalWaveManager.IsNodeReachable(startCourseNode, player.m_courseNode, out var path) && path.Length < closestDist)
+                {
+                    courseNode = player.m_courseNode;
+                    closestDist = path.Length;
+                }
+            }
+            if (courseNode == null) return true;
+
+            Vector3 normalized = (startCourseNode.Position - courseNode.Position).normalized;
+            normalized.y = 0f;
+            Il2CppSystem.Collections.Generic.List<ScoredSpawnPoint> availableSpawnPoints = __instance.GetAvailableSpawnPointsBetweenElevatorAndNode(courseNode);
+            ScoredSpawnPoint bestSP = new() { totalCost = float.MinValue };
+            Vector3 position = courseNode.Position;
+            float baseCost = 1f;
+            float costFactor = 4f - baseCost;
+
+            foreach (ScoredSpawnPoint currentSP in availableSpawnPoints)
+            {
+                Vector3 direction = currentSP.firstCoursePortal.Position - position;
+                direction.y = 0f;
+                direction.Normalize();
+                currentSP.m_dir = direction;
+                currentSP.totalCost = Mathf.Clamp01(Vector3.Dot(direction, normalized));
+
+                if (currentSP.pathHeat > baseCost - 0.01f)
+                {
+                    currentSP.totalCost += 1f + (1f - Mathf.Clamp(currentSP.pathHeat - baseCost, 0f, costFactor) / costFactor);
+                }
+                if (bestSP == null)
+                {
+                    bestSP = currentSP;
+                }
+                else if (currentSP.totalCost > bestSP.totalCost)
+                {
+                    bestSP = currentSP;
+                }
+            }
+
+            bestSP.courseNode ??= courseNode;
+            __result = bestSP;
+
+            return false;
+        }
+    }
+}

--- a/Patch_SurvivalWave_OnGroupSpawn.cs
+++ b/Patch_SurvivalWave_OnGroupSpawn.cs
@@ -11,13 +11,13 @@ using Player;
 namespace ExtraSurvivalWaveSettings
 {
     [HarmonyPatch]
-    internal class Patch_SurvivalWaveTest
+    internal class Patch_SurvivalWave_OnGroupSpawn
     {
         // This must happen here because the spawning should check how far it should spawn for every group
 
         [HarmonyPatch(typeof(SurvivalWave), nameof(SurvivalWave.SpawnGroup))]
         [HarmonyPrefix]
-        public static void InfoTestPatch(SurvivalWave __instance)
+        public static void SurvivalWave_SpawnGroup(SurvivalWave __instance)
         {
             if (SurvivalWaveManager.Current.LateSpawnTypeOverrideMap.TryGetValue(__instance.EventID, out (SurvivalWaveSpawnType, int) data))
             {
@@ -33,88 +33,10 @@ namespace ExtraSurvivalWaveSettings
                 }
                 if (type == SurvivalWaveSpawnType.ClosestToSuppliedNodeButNoBetweenPlayers)
                 {
-                    __instance.m_courseNode = GetNodeAtDistanceFromPlayerToSupplied(node, (int)__instance.m_areaDistance);
+                    __instance.m_courseNode = SurvivalWaveManager.GetNodeAtDistanceFromPlayerToSupplied(node, (int)__instance.m_areaDistance);
                     __instance.m_spawnType = SurvivalWaveSpawnType.InSuppliedCourseNode;
                 }
             }
-        }
-
-        public static AIG_CourseNode GetNodeAtDistanceFromPlayerToSupplied(AIG_CourseNode dest_node, int area_distance)
-        {
-            // If below fails, default to the defined node as if it were `InSuppliedCourseNode`
-            // Could maybe instead try to find the closest node to dest before blocked if it's blocked?
-            var NodeToSpawnAt = dest_node;
-
-            int maxdist = int.MaxValue;
-            AIG_CourseNode[] closestPath = null;
-            foreach (var player in PlayerManager.PlayerAgentsInLevel)
-            {
-                if (IsNodeReachable(player.m_courseNode, dest_node, out AIG_CourseNode[] path) && path.Length < maxdist)
-                {
-                    closestPath = path;
-                    maxdist = path.Length;
-                }
-            }
-
-            if (closestPath != null)
-            {
-                if (closestPath.Length > area_distance)
-                    NodeToSpawnAt = closestPath[area_distance];
-            }
-            else
-                ESWSLogger.Error("GetNodeAtDistanceFromPlayerToSupplied: No path from any player to supplied node!");
-
-            return NodeToSpawnAt;
-
-        }
-
-        // Checks if the target node can be reached by the source node, and returns the node path up to (but not including) the target node
-        // "Reachable" refers to there being no closed security doors between source and target.
-        // This was originally made by randomuserhi, based on `AIG_CourseGraph.GetDistanceBetweenToNodes()` to account for closed doors
-        private static bool IsNodeReachable(AIG_CourseNode source, AIG_CourseNode target, out AIG_CourseNode[] pathToNode)
-        {
-            pathToNode = null;
-
-            if (source == null || target == null) return false;
-            if (source.NodeID == target.NodeID)
-            {
-                pathToNode = [];
-                return true;
-            }
-
-            AIG_SearchID.IncrementSearchID();
-            ushort searchID = AIG_SearchID.SearchID;
-            Queue<(AIG_CourseNode, AIG_CourseNode[])> queue = new Queue<(AIG_CourseNode, AIG_CourseNode[])>();
-            queue.Enqueue((source, []));
-
-            while (queue.Count > 0)
-            {
-                var (current, path) = queue.Dequeue();
-                current.m_searchID = searchID;
-
-                AIG_CourseNode[] newPath = [.. path, current];
-
-                foreach (AIG_CoursePortal portal in current.m_portals)
-                {
-                    LG_SecurityDoor? secDoor = portal.Gate?.SpawnedDoor?.TryCast<LG_SecurityDoor>();
-                    if (secDoor != null)
-                    {
-                        if (secDoor.LastStatus != eDoorStatus.Open && secDoor.LastStatus != eDoorStatus.Opening)
-                            continue;
-                    }
-                    AIG_CourseNode nextNode = portal.GetOppositeNode(current);
-                    if (nextNode.m_searchID == searchID) continue;
-                    if (nextNode.NodeID == target.NodeID)
-                    {
-                        pathToNode = newPath;
-                        return true;
-                    }
-
-                    queue.Enqueue((nextNode, newPath));
-                }
-            }
-
-            return false;
         }
 
     }

--- a/SurvivalWaveManager.cs
+++ b/SurvivalWaveManager.cs
@@ -178,6 +178,83 @@ namespace ExtraSurvivalWaveSettings
             });
         }
 
+        public static AIG_CourseNode GetNodeAtDistanceFromPlayerToSupplied(AIG_CourseNode dest_node, int area_distance)
+        {
+            // If below fails, default to the defined node as if it were `InSuppliedCourseNode`
+            // Could maybe instead try to find the closest node to dest before blocked if it's blocked?
+            var NodeToSpawnAt = dest_node;
+
+            int maxdist = int.MaxValue;
+            AIG_CourseNode[] closestPath = null;
+            foreach (var player in PlayerManager.PlayerAgentsInLevel)
+            {
+                if (IsNodeReachable(player.m_courseNode, dest_node, out AIG_CourseNode[] path) && path.Length < maxdist)
+                {
+                    closestPath = path;
+                    maxdist = path.Length;
+                }
+            }
+
+            if (closestPath != null)
+            {
+                if (closestPath.Length > area_distance)
+                    NodeToSpawnAt = closestPath[area_distance];
+            }
+            else
+                ESWSLogger.Error("GetNodeAtDistanceFromPlayerToSupplied: No path from any player to supplied node!");
+
+            return NodeToSpawnAt;
+        }
+
+        // Checks if the target node can be reached by the source node, and returns the node path up to (but not including) the target node
+        // "Reachable" refers to there being no closed security doors between source and target.
+        // This was originally made by randomuserhi, based on `AIG_CourseGraph.GetDistanceBetweenToNodes()` to account for closed doors
+        internal static bool IsNodeReachable(AIG_CourseNode source, AIG_CourseNode target, out AIG_CourseNode[] pathToNode)
+        {
+            pathToNode = null;
+
+            if (source == null || target == null) return false;
+            if (source.NodeID == target.NodeID)
+            {
+                pathToNode = [];
+                return true;
+            }
+
+            AIG_SearchID.IncrementSearchID();
+            ushort searchID = AIG_SearchID.SearchID;
+            Queue<(AIG_CourseNode, AIG_CourseNode[])> queue = new Queue<(AIG_CourseNode, AIG_CourseNode[])>();
+            queue.Enqueue((source, []));
+
+            while (queue.Count > 0)
+            {
+                var (current, path) = queue.Dequeue();
+                current.m_searchID = searchID;
+
+                AIG_CourseNode[] newPath = [.. path, current];
+
+                foreach (AIG_CoursePortal portal in current.m_portals)
+                {
+                    LG_SecurityDoor? secDoor = portal.Gate?.SpawnedDoor?.TryCast<LG_SecurityDoor>();
+                    if (secDoor != null)
+                    {
+                        if (secDoor.LastStatus != eDoorStatus.Open && secDoor.LastStatus != eDoorStatus.Opening)
+                            continue;
+                    }
+                    AIG_CourseNode nextNode = portal.GetOppositeNode(current);
+                    if (nextNode.m_searchID == searchID) continue;
+                    if (nextNode.NodeID == target.NodeID)
+                    {
+                        pathToNode = newPath;
+                        return true;
+                    }
+
+                    queue.Enqueue((nextNode, newPath));
+                }
+            }
+
+            return false;
+        }
+
         internal void OnStopAllWave()
         {
             // Clarity that it's referring to the below method.


### PR DESCRIPTION
(On behalf of @Amorously)

This includes another patch that was originally included in [DoubleSidedDoors](https://github.com/randomuserhi/GTFODoubleSidedDoors/blob/amor-re-master/DoubleSidedDoors/Module/Patches/Patch_FromElevatorSpawn.cs), It duplicates the vanilla logic for getting valid spawn nodes between a player and the spawn, or elevator, node and choosing valid spawn points. The difference is it ensures that the player it chooses is the closest to the elevator room-wise instead of the seemingly faulty logic used in `PlayerManager.TryGetClosestAlivePlayerAgent()`

This also fixes up a couple minor text mistakes from #1, mainly a class and method that still had test names.

Also, thunderstore update soon? 🙏 